### PR TITLE
#3 fixes wrong next() modification when using sip object

### DIFF
--- a/pyanatomist/python/anatomist/cpp/mobject.py
+++ b/pyanatomist/python/anatomist/cpp/mobject.py
@@ -6,9 +6,9 @@
 #
 # This software is governed by the CeCILL license version 2 under
 # French law and abiding by the rules of distribution of free software.
-# You can  use, modify and/or redistribute the software under the 
+# You can  use, modify and/or redistribute the software under the
 # terms of the CeCILL license version 2 as circulated by CEA, CNRS
-# and INRIA at the following URL "http://www.cecill.info". 
+# and INRIA at the following URL "http://www.cecill.info".
 #
 # As a counterpart to the access to the source code and  rights to copy,
 # modify and redistribute granted by the license, users are provided only
@@ -23,8 +23,8 @@
 # therefore means  that it is reserved for developers  and  experienced
 # professionals having in-depth computer knowledge. Users are therefore
 # encouraged to load and test the software's suitability as regards their
-# requirements in conditions enabling the security of their systems and/or 
-# data to be ensured and,  more generally, to use and operate it in the 
+# requirements in conditions enabling the security of their systems and/or
+# data to be ensured and,  more generally, to use and operate it in the
 # same conditions as regards security.
 #
 # The fact that you are presently reading this means that you have had
@@ -54,7 +54,7 @@ class MIterator:
             object = getattr(self, '_object', None)
             if iterator is not None and object is not None \
                     and iterator != object.end():
-                return next(iterator)
+                return iterator.next()
             else:
                 raise StopIteration('iterator outside bounds')
     else:
@@ -63,7 +63,7 @@ class MIterator:
             object = getattr(self, '_object', None)
             if iterator is not None and object is not None \
                     and iterator != object.end():
-                return next(iterator)
+                return iterator.next()
             else:
                 raise StopIteration('iterator outside bounds')
 


### PR DESCRIPTION
In this case, it happens that an AIterator is used, and so the builtin function `next` doesn't work.
Reverting changes from python-modernize to keep the use of `.next()` can solve the issue #3

I fixes this particular file, but it is possible that this is also the same case in other files.