### PR TITLE
Straighten Python 2/3 compatibility of MObject / AIterator

### DIFF
--- a/pyanatomist/python/anatomist/cpp/__init__.py
+++ b/pyanatomist/python/anatomist/cpp/__init__.py
@@ -196,7 +196,7 @@ qt_backend.set_qt_backend(compatible_qt5=True, pyqt_api=2)
 
 from anatomistsip import *
 
-aims.__fixsipclasses__(list(locals().items()))
+aims.__fixsipclasses__(list(globals().items()))
 
 loaded_modules = []
 global _anatomist_modsloaded

--- a/pyanatomist/python/anatomist/cpp/mobject.py
+++ b/pyanatomist/python/anatomist/cpp/mobject.py
@@ -37,8 +37,9 @@ The anatomist module allows access to the Anatomist library in python.
 from __future__ import absolute_import
 import sys
 anatomist = sys.modules[ 'anatomist.cpp' ]
-# Iterator (doesn't work when implemented in SIP so far)
 
+# Iterator a Python iterator on top of AIterator (we did not manage to
+# implement AIterator.__next__ correctly in SIP so far).
 class MIterator:
     def __init__( self, object ):
         if object is not None:
@@ -48,24 +49,16 @@ class MIterator:
     def __iter__(self):
         return self
 
-    if sys.version_info[0] >= 3:
-        def __next__(self):
-            iterator = getattr(self, '_iterator', None)
-            object = getattr(self, '_object', None)
-            if iterator is not None and object is not None \
-                    and iterator != object.end():
-                return iterator.next()
-            else:
-                raise StopIteration('iterator outside bounds')
-    else:
-        def next(self):
-            iterator = getattr(self, '_iterator', None)
-            object = getattr(self, '_object', None)
-            if iterator is not None and object is not None \
-                    and iterator != object.end():
-                return iterator.next()
-            else:
-                raise StopIteration('iterator outside bounds')
+    def __next__(self):
+        iterator = getattr(self, '_iterator', None)
+        object = getattr(self, '_object', None)
+        if iterator is not None and object is not None \
+           and iterator != object.end():
+            return iterator.next()  # do not replace with next(iterator)
+        else:
+            raise StopIteration('iterator outside bounds')
+
+    next = __next__  # Python 2 compatibility
 
 def newiter(self):
     return MIterator(self)

--- a/pyanatomist/python/anatomist/direct/api.py
+++ b/pyanatomist/python/anatomist/direct/api.py
@@ -1492,7 +1492,9 @@ class Anatomist(base.Anatomist, cpp.Anatomist):
                 return self.objectType
             elif name == "children":
                 objects = []
-                if issubclass(type(self.getInternalRep()), cpp.MObject):  # if internalRep is a multi object, it is iterable and can have children
+                # if internalRep is a multi object, it is iterable and can have
+                # children
+                if isinstance(self.getInternalRep(), cpp.MObject):
                     for c in self.getInternalRep():
                         objects.append(self.anatomistinstance.typedObject(c))
                 return objects

--- a/pyanatomist/src/sip/mobject.sip
+++ b/pyanatomist/src/sip/mobject.sip
@@ -32,10 +32,12 @@ public:
       ++(*sipCpp);
 %End
 
-   anatomist::AIterator* __iter__() /Factory/;
-%MethodCode
-   sipRes = new anatomist::AIterator( *sipCpp );
-%End
+// This method should be commented out as long as this is not a proper iterator
+// in the Python sense. See pyanatomist/python/anatomist/cpp/mobject.py.
+//    anatomist::AIterator* __iter__() /Factory/;
+// %MethodCode
+//    sipRes = new anatomist::AIterator( *sipCpp );
+// %End
 };
 
 class MObject : anatomist::AObject /Abstract/
@@ -98,10 +100,14 @@ public:
     }
 %End
 
-    anatomist::AIterator *__iter__() /Factory/;
-%MethodCode
-    sipRes = new anatomist::AIterator( sipCpp->begin() );
-%End
+// At the moment __iter__ is patched in plain Python (see
+// pyanatomist/python/anatomist/cpp/mobject.py), because AIterator is not a
+// proper iterator in the Python sense.
+//
+//     anatomist::AIterator *__iter__() /Factory/;
+// %MethodCode
+//     sipRes = new anatomist::AIterator( sipCpp->begin() );
+// %End
 };
 
 };


### PR DESCRIPTION
This should be a proper fix for https://github.com/brainvisa/anatomist-gpl/issues/3